### PR TITLE
Migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+/.vs

--- a/HtmlElements.IntegrationTests/HtmlElements.IntegrationTests.csproj
+++ b/HtmlElements.IntegrationTests/HtmlElements.IntegrationTests.csproj
@@ -45,13 +45,11 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="WebDriver, Version=2.53.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.2.53.1\lib\net40\WebDriver.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WebDriver, Version=3.5.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.3.5.2\lib\net40\WebDriver.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=2.49.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.Support.2.49.0\lib\net40\WebDriver.Support.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WebDriver.Support, Version=3.5.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.3.5.2\lib\net40\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/HtmlElements.IntegrationTests/HtmlElements.IntegrationTests.csproj
+++ b/HtmlElements.IntegrationTests/HtmlElements.IntegrationTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -12,6 +13,8 @@
     <AssemblyName>HtmlElements.IntegrationTests</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,9 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -87,7 +89,16 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/HtmlElements.IntegrationTests/packages.config
+++ b/HtmlElements.IntegrationTests/packages.config
@@ -3,6 +3,6 @@
   <package id="NUnit" version="3.8.1" targetFramework="net40" />
   <package id="NUnit3TestAdapter" version="3.8.0" targetFramework="net40" />
   <package id="PhantomJS" version="2.1.1" targetFramework="net40" />
-  <package id="Selenium.Support" version="2.49.0" targetFramework="net40" />
-  <package id="Selenium.WebDriver" version="2.53.1" targetFramework="net40" />
+  <package id="Selenium.Support" version="3.5.2" targetFramework="net40" />
+  <package id="Selenium.WebDriver" version="3.5.2" targetFramework="net40" />
 </packages>

--- a/HtmlElements.IntegrationTests/packages.config
+++ b/HtmlElements.IntegrationTests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net40" />
+  <package id="NUnit" version="3.8.1" targetFramework="net40" />
+  <package id="NUnit3TestAdapter" version="3.8.0" targetFramework="net40" />
   <package id="PhantomJS" version="2.1.1" targetFramework="net40" />
   <package id="Selenium.Support" version="2.49.0" targetFramework="net40" />
   <package id="Selenium.WebDriver" version="2.53.1" targetFramework="net40" />

--- a/HtmlElements.IntegrationTests/src/ElementListTests.cs
+++ b/HtmlElements.IntegrationTests/src/ElementListTests.cs
@@ -17,7 +17,7 @@ namespace HtmlElements.IntegrationTests
 
             PageAlpha.ElementListContainer.InnerHtml += "<li>new list item</li>";
 
-            Expect(PageAlpha.ElementListItems.Count, Is.GreaterThan(initElementCount));
+            Assert.That(PageAlpha.ElementListItems.Count, Is.GreaterThan(initElementCount));
         }
 
         [Test]
@@ -27,7 +27,7 @@ namespace HtmlElements.IntegrationTests
 
             PageAlpha.ElementListContainer.InnerHtml = "<li>alpha</li><li>beta</li>";
 
-            Expect(firstElement.Text, Is.EqualTo("alpha"));
+            Assert.That(firstElement.Text, Is.EqualTo("alpha"));
         }
 
         [Test]
@@ -37,7 +37,7 @@ namespace HtmlElements.IntegrationTests
 
             PageAlpha.ElementListContainer.InnerHtml = String.Empty;
 
-            Expect(() => firstElement.Text, Throws.InstanceOf<NoSuchElementException>());
+            Assert.That(() => firstElement.Text, Throws.InstanceOf<NoSuchElementException>());
         }
 
         [Test]
@@ -47,7 +47,7 @@ namespace HtmlElements.IntegrationTests
 
             PageAlpha.ElementListContainer.InnerHtml += "<li>new list item</li>";
 
-            Expect(PageAlpha.CachedElementListItems.Count, Is.EqualTo(initElementCount));
+            Assert.That(PageAlpha.CachedElementListItems.Count, Is.EqualTo(initElementCount));
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace HtmlElements.IntegrationTests
 
             PageAlpha.ElementListContainer.InnerHtml = "<li>alpha</li><li>beta</li>";
 
-            Expect(firstElement.Text, Is.EqualTo("alpha"));
+            Assert.That(firstElement.Text, Is.EqualTo("alpha"));
         }
 
         [Test]
@@ -65,11 +65,11 @@ namespace HtmlElements.IntegrationTests
         {
             var element = PageAlpha.CachedElementListItems[0];
 
-            Expect(element.ToString(), 
-                ContainsSubstring(typeof(HtmlElement).Name)
-                .And.ContainsSubstring(typeof(WebElementProxy).Name)
-                .And.ContainsSubstring(typeof(WebElementListItemLoader).Name)
-                .And.ContainsSubstring(typeof(WebElementListLoader).Name));
+            Assert.That(element.ToString(), 
+                Does.Contain(typeof(HtmlElement).Name)
+                .And.Contain(typeof(WebElementProxy).Name)
+                .And.Contain(typeof(WebElementListItemLoader).Name)
+                .And.Contain(typeof(WebElementListLoader).Name));
         }
     }
 }

--- a/HtmlElements.IntegrationTests/src/IntegrationTestFixture.cs
+++ b/HtmlElements.IntegrationTests/src/IntegrationTestFixture.cs
@@ -7,7 +7,8 @@ using OpenQA.Selenium.PhantomJS;
 
 namespace HtmlElements.IntegrationTests {
 
-    public class IntegrationTestFixture : AssertionHelper {
+    public class IntegrationTestFixture
+    {
 
         private const String InitialUrl = "PageAlpha.htm";
 
@@ -18,18 +19,22 @@ namespace HtmlElements.IntegrationTests {
         protected PageAlpha PageAlpha { get; private set; }
 
         [SetUp]
-        public void OpenTestPage() {
+        public void OpenTestPage()
+        {
             WebDriver.Navigate().GoToUrl(new Uri(Path.GetFullPath(InitialUrl)).AbsoluteUri);
             PageAlpha = PageFactory.Create<PageAlpha>(WebDriver);
         }
 
-        [TestFixtureSetUp]
-        public void InitBrowser() {
+        [OneTimeSetUp]
+        public void InitBrowser()
+        {
+            Environment.CurrentDirectory = Path.GetDirectoryName(this.GetType().Assembly.Location);
             WebDriver = new PhantomJSDriver();
         }
 
-        [TestFixtureTearDown]
-        public void CloseBrowser() {
+        [OneTimeTearDown]
+        public void CloseBrowser()
+        {
             WebDriver.Quit();
         }
 

--- a/HtmlElements.IntegrationTests/src/PageControlTests.cs
+++ b/HtmlElements.IntegrationTests/src/PageControlTests.cs
@@ -22,10 +22,10 @@ namespace HtmlElements.IntegrationTests
         public void ControlShouldHaveMeaningfullStringRepresentation()
         {
             Assert.That(PageAlpha.NonCachedBetaFrame.SubmitBtn.ToString(),
-                ContainsSubstring(typeof(HtmlElement).Name)
-                .And.ContainsSubstring(typeof(WebElementProxy).Name)
-                .And.ContainsSubstring(typeof(WebElementLoader).Name)
-                .And.ContainsSubstring(typeof(FrameWebElementProxy).Name));
+                Does.Contain(typeof(HtmlElement).Name)
+                .And.Contain(typeof(WebElementProxy).Name)
+                .And.Contain(typeof(WebElementLoader).Name)
+                .And.Contain(typeof(FrameWebElementProxy).Name));
         }
 
         [Test]

--- a/Selenium.HtmlElements.Test/HtmlElements.Test.csproj
+++ b/Selenium.HtmlElements.Test/HtmlElements.Test.csproj
@@ -47,13 +47,11 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="WebDriver, Version=2.48.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.2.48.2\lib\net40\WebDriver.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WebDriver, Version=3.5.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.3.5.2\lib\net40\WebDriver.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=2.48.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.Support.2.48.2\lib\net40\WebDriver.Support.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WebDriver.Support, Version=3.5.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.3.5.2\lib\net40\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Selenium.HtmlElements.Test/HtmlElements.Test.csproj
+++ b/Selenium.HtmlElements.Test/HtmlElements.Test.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +12,8 @@
     <AssemblyName>HtmlElements.Test</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,11 +35,9 @@
   <ItemGroup>
     <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -82,8 +83,16 @@
       <Name>HtmlElements</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Selenium.HtmlElements.Test/Properties/AssemblyInfo.cs
+++ b/Selenium.HtmlElements.Test/Properties/AssemblyInfo.cs
@@ -13,3 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: Guid("5b734016-265c-4ba4-ac1e-39b76adbed6a")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: NUnit.Framework.Parallelizable(NUnit.Framework.ParallelScope.Fixtures)]

--- a/Selenium.HtmlElements.Test/packages.config
+++ b/Selenium.HtmlElements.Test/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1510.2205" targetFramework="net40" />
-  <package id="NUnit" version="2.6.4" targetFramework="net40" />
+  <package id="NUnit" version="3.8.1" targetFramework="net40" />
+  <package id="NUnit3TestAdapter" version="3.8.0" targetFramework="net40" />
   <package id="Selenium.Support" version="2.48.2" targetFramework="net40" />
   <package id="Selenium.WebDriver" version="2.48.2" targetFramework="net40" />
 </packages>

--- a/Selenium.HtmlElements.Test/packages.config
+++ b/Selenium.HtmlElements.Test/packages.config
@@ -3,6 +3,6 @@
   <package id="Moq" version="4.2.1510.2205" targetFramework="net40" />
   <package id="NUnit" version="3.8.1" targetFramework="net40" />
   <package id="NUnit3TestAdapter" version="3.8.0" targetFramework="net40" />
-  <package id="Selenium.Support" version="2.48.2" targetFramework="net40" />
-  <package id="Selenium.WebDriver" version="2.48.2" targetFramework="net40" />
+  <package id="Selenium.Support" version="3.5.2" targetFramework="net40" />
+  <package id="Selenium.WebDriver" version="3.5.2" targetFramework="net40" />
 </packages>

--- a/Selenium.HtmlElements.Test/src/Extensions/TypeExtensionsTests.cs
+++ b/Selenium.HtmlElements.Test/src/Extensions/TypeExtensionsTests.cs
@@ -13,29 +13,29 @@ namespace HtmlElements.Test.Extensions
 {
     public class TypeExtensionsTests
     {
-        [TestCase(null, Result = false)]
-        [TestCase(typeof(Object), Result = false)]
-        [TestCase(typeof(IWebDriver), Result = false)]
-        [TestCase(typeof(ISearchContext), Result = false)]
-        [TestCase(typeof(IHtmlElement), Result = true)]
-        [TestCase(typeof(IWebElement), Result = true)]
-        [TestCase(typeof(HtmlElement), Result = true)]
-        [TestCase(typeof(WebElementImpl), Result = true)]
+        [TestCase(null, ExpectedResult = false)]
+        [TestCase(typeof(Object), ExpectedResult = false)]
+        [TestCase(typeof(IWebDriver), ExpectedResult = false)]
+        [TestCase(typeof(ISearchContext), ExpectedResult = false)]
+        [TestCase(typeof(IHtmlElement), ExpectedResult = true)]
+        [TestCase(typeof(IWebElement), ExpectedResult = true)]
+        [TestCase(typeof(HtmlElement), ExpectedResult = true)]
+        [TestCase(typeof(WebElementImpl), ExpectedResult = true)]
         public Boolean ShouldDetermineWeatherTypeIsDerivedFromWebElement(Type type)
         {
             return type.IsWebElement();
         }
 
-        [TestCase(typeof(IList<IWebElement>), Result = true)]
-        [TestCase(typeof(IList<WebElementImpl>), Result = true)]
-        [TestCase(typeof(IList<IHtmlElement>), Result = true)]
-        [TestCase(typeof(IList<HtmlElement>), Result = true)]
-        [TestCase(typeof(IList<Object>), Result = false)]
-        [TestCase(typeof(IList<IWebDriver>), Result = false)]
-        [TestCase(typeof(IList<ISearchContext>), Result = false)]
-        [TestCase(typeof(IEnumerable<IWebElement>), Result = false)]
-        [TestCase(typeof(ICollection<IWebElement>), Result = false)]
-        [TestCase(typeof(List<IWebElement>), Result = false)]
+        [TestCase(typeof(IList<IWebElement>), ExpectedResult = true)]
+        [TestCase(typeof(IList<WebElementImpl>), ExpectedResult = true)]
+        [TestCase(typeof(IList<IHtmlElement>), ExpectedResult = true)]
+        [TestCase(typeof(IList<HtmlElement>), ExpectedResult = true)]
+        [TestCase(typeof(IList<Object>), ExpectedResult = false)]
+        [TestCase(typeof(IList<IWebDriver>), ExpectedResult = false)]
+        [TestCase(typeof(IList<ISearchContext>), ExpectedResult = false)]
+        [TestCase(typeof(IEnumerable<IWebElement>), ExpectedResult = false)]
+        [TestCase(typeof(ICollection<IWebElement>), ExpectedResult = false)]
+        [TestCase(typeof(List<IWebElement>), ExpectedResult = false)]
         public Boolean ShouldDetermineWeatherTypeDescribedListOfWebElements(Type type)
         {
             return type.IsWebElementList();

--- a/Selenium.HtmlElements.Test/src/Extensions/TypeExtensionsTests.cs
+++ b/Selenium.HtmlElements.Test/src/Extensions/TypeExtensionsTests.cs
@@ -123,6 +123,11 @@ namespace HtmlElements.Test.Extensions
                 throw new NotImplementedException();
             }
 
+            public string GetProperty(string propertyName)
+            {
+                throw new NotImplementedException();
+            }
+
             public string TagName { get; set; }
             public string Text { get; set; }
             public bool Enabled { get; set; }

--- a/Selenium.HtmlElements.Test/src/Extensions/WaitForPresentWebElementExtensionTests.cs
+++ b/Selenium.HtmlElements.Test/src/Extensions/WaitForPresentWebElementExtensionTests.cs
@@ -9,7 +9,7 @@ namespace HtmlElements.Test.Extensions
 {
     public class WaitForPresentWebElementExtensionTests : AbstractWebElementExtensionsTestFixture
     {
-        private static IEnumerable<ITestCaseData> WaitForPresentTestCases
+        private static IEnumerable<object> WaitForPresentTestCases
         {
             get
             {

--- a/Selenium.HtmlElements.Test/src/Extensions/WaitForVisibleWebElementExtensionTests.cs
+++ b/Selenium.HtmlElements.Test/src/Extensions/WaitForVisibleWebElementExtensionTests.cs
@@ -8,7 +8,7 @@ namespace HtmlElements.Test.Extensions
 {
     public class WaitForVisibleWebElementExtensionTests : AbstractWebElementExtensionsTestFixture
     {
-        private static IEnumerable<ITestCaseData> WaitForVisibleTestCases
+        private static IEnumerable<object> WaitForVisibleTestCases
         {
             get
             {

--- a/Selenium.HtmlElements.Test/src/Extensions/WaitUntilHiddenWebElementExtensionTests.cs
+++ b/Selenium.HtmlElements.Test/src/Extensions/WaitUntilHiddenWebElementExtensionTests.cs
@@ -8,7 +8,7 @@ namespace HtmlElements.Test.Extensions
 {
     public class WaitUntilHiddenWebElementExtensionTests : AbstractWebElementExtensionsTestFixture
     {
-        private static IEnumerable<ITestCaseData> WaitUntilHiddenTestCases
+        private static IEnumerable<object> WaitUntilHiddenTestCases
         {
             get
             {

--- a/Selenium.HtmlElements/HtmlElements.csproj
+++ b/Selenium.HtmlElements/HtmlElements.csproj
@@ -42,13 +42,11 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="WebDriver, Version=2.48.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.2.48.2\lib\net40\WebDriver.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WebDriver, Version=3.5.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.3.5.2\lib\net40\WebDriver.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=2.48.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.Support.2.48.2\lib\net40\WebDriver.Support.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WebDriver.Support, Version=3.5.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.3.5.2\lib\net40\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -106,7 +104,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="nuget-package" DependsOnTargets="Build">
     <Exec Command="nuget spec" />

--- a/Selenium.HtmlElements/packages.config
+++ b/Selenium.HtmlElements/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
-  <package id="Selenium.Support" version="2.48.2" targetFramework="net40" />
-  <package id="Selenium.WebDriver" version="2.48.2" targetFramework="net40" />
+  <package id="Selenium.Support" version="3.5.2" targetFramework="net40" />
+  <package id="Selenium.WebDriver" version="3.5.2" targetFramework="net40" />
 </packages>

--- a/Selenium.HtmlElements/src/Elements/HtmlElement.cs
+++ b/Selenium.HtmlElements/src/Elements/HtmlElement.cs
@@ -4,12 +4,14 @@ using HtmlElements.Extensions;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Internal;
 
-namespace HtmlElements.Elements {
+namespace HtmlElements.Elements
+{
 
     /// <summary>
     ///     Models HTML DOM element providing access to common attributes and properties
     /// </summary>
-    public class HtmlElement : WebDriverWrapper, IHtmlElement {
+    public class HtmlElement : WebDriverWrapper, IHtmlElement
+    {
 
         private readonly IWebElement _wrappedElement;
 
@@ -30,36 +32,49 @@ namespace HtmlElements.Elements {
         /// <summary>
         ///     A WebElement, representing the parent node of current element, or null if it has no parent
         /// </summary>
-        public IWebElement ParentNode {
-            get { return this.GetProperty("parentNode") as IWebElement; }
+        public IWebElement ParentNode
+        {
+            get { return this.GetProperty<IWebElement>("parentNode"); }
         }
 
         /// <summary>
         ///     A previous node of current web element, in the same tree level
         /// </summary>
-        public IWebElement PreviousSibling {
-            get { return this.GetProperty("previousSibling") as IWebElement; }
+        public IWebElement PreviousSibling
+        {
+            get { return this.GetProperty<IWebElement>("previousSibling"); }
+        }
+
+        /// <summary>
+        ///     The next node of current web element, in the same tree level
+        /// </summary>
+        public IWebElement NextSibling
+        {
+            get { return this.GetProperty<IWebElement>("nextSibling"); }
         }
 
         /// <summary>
         ///     First child node of the web element, as a web element
         /// </summary>
-        public IWebElement FirstChild {
-            get { return this.GetProperty("firstChild") as IWebElement; }
+        public IWebElement FirstChild
+        {
+            get { return this.GetProperty<IWebElement>("firstChild"); }
         }
 
         /// <summary>
         ///     Last child node of the current element, as a web element
         /// </summary>
-        public IWebElement LastChild {
-            get { return this.GetProperty("lastChild") as IWebElement; }
+        public IWebElement LastChild
+        {
+            get { return this.GetProperty<IWebElement>("lastChild"); }
         }
 
         /// <summary>
         ///     HTML content of an element
         /// </summary>
-        public String InnerHtml {
-            get { return this.GetProperty("innerHTML") as String; }
+        public String InnerHtml
+        {
+            get { return this.GetProperty<string>("innerHTML"); }
             set { this.SetPropery("innerHTML", value); }
         }
 
@@ -68,7 +83,8 @@ namespace HtmlElements.Elements {
         ///     On returning text, this property returns the value of all text nodes within the element node.
         ///     On setting text, this property removes all child nodes and replaces them with a single text node.
         /// </summary>
-        public String TextContent {
+        public String TextContent
+        {
             get { return this.GetProperty("textContent") as String; }
             set { this.SetPropery("textContent", value); }
         }
@@ -76,7 +92,8 @@ namespace HtmlElements.Elements {
         /// <summary>
         ///     Gets or sets 'name' attribute of the underlying DOM element or null if it does not exist
         /// </summary>
-        public string Name {
+        public string Name
+        {
             get { return GetAttribute("name"); }
             set { this.SetAttribute("name", value); }
         }
@@ -84,7 +101,8 @@ namespace HtmlElements.Elements {
         /// <summary>
         ///     Gets or sets 'id' attribute of the underlying DOM element or null if it does not exist
         /// </summary>
-        public string Id {
+        public string Id
+        {
             get { return GetAttribute("id"); }
             set { this.SetAttribute("id", value); }
         }
@@ -92,7 +110,8 @@ namespace HtmlElements.Elements {
         /// <summary>
         ///    Gets or sets 'class' attribute of the underlying DOM element or null if it does not exist
         /// </summary>
-        public string Class {
+        public string Class
+        {
             get { return GetAttribute("class"); }
             set { this.SetAttribute("class", value); }
         }
@@ -100,7 +119,8 @@ namespace HtmlElements.Elements {
         /// <summary>
         ///     Gets or sets 'style' attribute of the underlying DOM element or null if it does not exist
         /// </summary>
-        public string Style {
+        public string Style
+        {
             get { return GetAttribute("style"); }
             set { this.SetAttribute("style", value); }
         }
@@ -108,7 +128,8 @@ namespace HtmlElements.Elements {
         /// <summary>
         ///     Gets or sets 'title' attribute of the underlying DOM element or null if it does not exist
         /// </summary>
-        public string Title {
+        public string Title
+        {
             get { return GetAttribute("title"); }
             set { this.SetAttribute("title", value); }
         }
@@ -120,7 +141,8 @@ namespace HtmlElements.Elements {
         ///     If this element is a text entry element, the method will clear the value. 
         ///     It has no effect on other elements. Text entry elements are defined as elements with INPUT or TEXTAREA tags.
         /// </remarks>
-        public void Clear() {
+        public void Clear()
+        {
             _wrappedElement.Clear();
         }
 
@@ -132,7 +154,8 @@ namespace HtmlElements.Elements {
         ///     The text to be typed may include special characters like arrow keys, backspaces, function keys, and so on. 
         ///     Valid special keys are defined in <see cref="Keys"/>.
         /// </remarks>
-        public void SendKeys(string text) {
+        public void SendKeys(string text)
+        {
             _wrappedElement.SendKeys(text);
         }
 
@@ -143,7 +166,8 @@ namespace HtmlElements.Elements {
         ///     If this current element is a form, or an element within a form, then this will be submitted to the web server. 
         ///     If this causes the current page to change, then this method will block until the new page is loaded.
         /// </remarks>
-        public void Submit() {
+        public void Submit()
+        {
             _wrappedElement.Submit();
         }
 
@@ -157,7 +181,8 @@ namespace HtmlElements.Elements {
         ///     If this element is not clickable, then this operation is ignored. 
         ///     This allows you to simulate a users to accidentally missing the target when clicking.
         /// </remarks>
-        public void Click() {
+        public void Click()
+        {
             _wrappedElement.Click();
         }
 
@@ -171,8 +196,23 @@ namespace HtmlElements.Elements {
         ///     Note that the value of the following attributes will be returned even if there is no explicit attribute on the element: 
         ///     Attribute nameValue returned if not explicitly specified.
         /// </remarks>
-        public string GetAttribute(string attributeName) {
+        public string GetAttribute(string attributeName)
+        {
             return _wrappedElement.GetAttribute(attributeName);
+        }
+
+
+        /// <summary>
+        /// Gets the value of a JavaScript property of this element.
+        /// </summary>
+        /// <param name="propertyName"></param>
+        /// <returns>The JavaScript property's current value. Returns a null if the value is not set or the property does not exist.
+        ///</returns>
+        /// <exception cref="StaleElementReferenceException">Thrown when the target element is no longer valid in the document DOM.
+        /// </exception>
+        public string GetProperty(string propertyName)
+        {
+            return _wrappedElement.GetProperty(propertyName);
         }
 
         /// <summary>
@@ -185,15 +225,18 @@ namespace HtmlElements.Elements {
         ///     Color values should be returned as hex strings. 
         ///     For example, a "background-color" property set as "green" in the HTML source, will return "#008000" for its value.
         /// </remarks>
-        public string GetCssValue(string propertyName) {
+        public string GetCssValue(string propertyName)
+        {
             return _wrappedElement.GetCssValue(propertyName);
         }
 
         /// <summary>
         ///     Returns underlying web element wrapped by current <see cref="HtmlElement"/>
         /// </summary>
-        public IWebElement WrappedElement {
-            get {
+        public IWebElement WrappedElement
+        {
+            get
+            {
                 return _wrappedElement is IWrapsElement
                     ? (_wrappedElement as IWrapsElement).WrappedElement
                     : _wrappedElement;
@@ -203,14 +246,16 @@ namespace HtmlElements.Elements {
         /// <summary>
         ///     Gets the tag name of this element.
         /// </summary>
-        public string TagName {
+        public string TagName
+        {
             get { return _wrappedElement.TagName; }
         }
 
         /// <summary>
         ///     Gets the innerText of this element, without any leading or trailing whitespace, and with other whitespace collapsed.
         /// </summary>
-        public string Text {
+        public string Text
+        {
             get { return _wrappedElement.Text; }
         }
 
@@ -220,7 +265,8 @@ namespace HtmlElements.Elements {
         /// <remarks>
         ///     The property will generally return true for everything except explicitly disabled input elements.
         /// </remarks>
-        public bool Enabled {
+        public bool Enabled
+        {
             get { return _wrappedElement.Enabled; }
         }
 
@@ -230,28 +276,32 @@ namespace HtmlElements.Elements {
         /// <remarks>
         ///     This operation only applies to input elements such as checkboxes, options in a select element and radio buttons.
         /// </remarks>
-        public bool Selected {
+        public bool Selected
+        {
             get { return _wrappedElement.Selected; }
         }
 
         /// <summary>
         ///     Gets a <see cref="Point"/> object containing the coordinates of the upper-left corner of this element relative to the upper-left corner of the page.
         /// </summary>
-        public Point Location {
+        public Point Location
+        {
             get { return _wrappedElement.Location; }
         }
 
         /// <summary>
         ///     Gets object containing the height and width of this element.
         /// </summary>
-        public Size Size {
+        public Size Size
+        {
             get { return _wrappedElement.Size; }
         }
 
         /// <summary>
         ///     Gets a value indicating whether or not this element is displayed.
         /// </summary>
-        public bool Displayed {
+        public bool Displayed
+        {
             get { return _wrappedElement.IsPresent() && _wrappedElement.Displayed; }
         }
 
@@ -301,5 +351,7 @@ namespace HtmlElements.Elements {
 
             return PageObjectFactory.Create<TPage>(wd);
         }
+
+
     }
 }

--- a/Selenium.HtmlElements/src/Extensions/JavaScriptExtensions.cs
+++ b/Selenium.HtmlElements/src/Extensions/JavaScriptExtensions.cs
@@ -108,8 +108,9 @@ namespace HtmlElements.Extensions {
         /// <param name="element">Target element</param>
         /// <param name="propertyName">Property name</param>
         /// <returns>Value of the property</returns>
-        public static object GetProperty(this HtmlElement element, String propertyName) {
-            return element.ExecuteScriptOnSelf("return {self}[arguments[0]];", propertyName);
+        public static T GetProperty<T>(this HtmlElement element, String propertyName)
+        {
+            return (T)element.ExecuteScriptOnSelf("return {self}[arguments[0]];", propertyName);
         }
 
     }

--- a/Selenium.HtmlElements/src/Extensions/WebDriverExtensions.cs
+++ b/Selenium.HtmlElements/src/Extensions/WebDriverExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Specialized;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Web;
@@ -87,7 +86,7 @@ namespace HtmlElements.Extensions {
         /// <param name="webDriver">WebDriver capable of taking screen-shots</param>
         /// <param name="imagePath">Screen-shot file path</param>
         /// <param name="imageFormat">Image format in which screen-shot will be saved</param>
-        public static void SavePageImage(this ITakesScreenshot webDriver, string imagePath, ImageFormat imageFormat) {
+        public static void SavePageImage(this ITakesScreenshot webDriver, string imagePath, ScreenshotImageFormat imageFormat) {
             webDriver.GetScreenshot().SaveAsFile(imagePath, imageFormat);
         }
 

--- a/Selenium.HtmlElements/src/Proxy/AbstractWebElementProxy.cs
+++ b/Selenium.HtmlElements/src/Proxy/AbstractWebElementProxy.cs
@@ -91,6 +91,11 @@ namespace HtmlElements.Proxy
             return Execute(e => e.GetAttribute(attributeName));
         }
 
+        public string GetProperty(string propertyName)
+        {
+            return Execute(e => e.GetProperty(propertyName));
+        }
+
         public string GetCssValue(string propertyName)
         {
             return Execute(e => e.GetCssValue(propertyName));


### PR DESCRIPTION
Hi and thanks for this great framework. I've been using it more than 1 year already and now we stuck with upgrating to the latest selenium. This pull request contains the following:

- migrated to the latest selenium .net bindings (3.5.2).
As IHtmlElement now implemts its own GetProperty() method I decided to change your implementation to generic one: HtmlElement.GetProperty<T>

- all tests were migrated no NUnit 3.
It's time to move bit forward :)

- new extension property: HtmlElement.NextSibling